### PR TITLE
Changes to Forgejo Dockerfile & docker-compose

### DIFF
--- a/forgejo-1.19.3/Dockerfile
+++ b/forgejo-1.19.3/Dockerfile
@@ -1,23 +1,32 @@
-FROM ubuntu:rolling
+FROM debian:stable-slim
 
-RUN apt update && apt -y install\
-	git\
+RUN apt update && apt -y install \
+		git \
+		wget \
+		ca-certificates \
+		bash \
+	&& apt clean \	
 	&& rm -rf /var/lib/apt/lists/* 
 
-RUN mkdir /app
-COPY ./forgejo-1.19.3-0-linux-amd64 /app/forgejo
-RUN chmod +x /app/forgejo
-COPY ./entrypoint.sh /
+RUN wget -o forgejo https://codeberg.org/forgejo/forgejo/releases/download/v1.19.3-0/forgejo-1.19.3-0-linux-amd64 \
+	&& chmod +x forgejo \
+	&& mv forgejo /usr/local/bin/forgejo
 
-RUN useradd -m forgejo
-RUN usermod -aG forgejo forgejo
+COPY ./entrypoint.sh /entrypoint.sh
 
-RUN chown -R forgejo:forgejo /app
+RUN useradd -m forgejo \
+	&& usermod -aG forgejo forgejo \
+	&& mkdir /app \
+	&& chown -R forgejo:forgejo /app \
+	&& mkdir /app/data \
+	&& chown -R forgejo:forgejo /app/data \
+	&& mkdir /app/custom \
+	&& chown -R forgejo:forgejo /app/custom \
+	&& mkdir /app/logs \
+	&& chown -R forgejo:forgejo /app/logs
 
-
-RUN mkdir /app/data
 WORKDIR /app
 
-ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
-CMD ["/app/forgejo", "web"]
+CMD ["/usr/local/bin/forgejo", "web"]

--- a/forgejo-1.19.3/Dockerfile
+++ b/forgejo-1.19.3/Dockerfile
@@ -27,6 +27,6 @@ RUN useradd -m forgejo \
 
 WORKDIR /app
 
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"] #may need to be refactored
 
 CMD ["/usr/local/bin/forgejo", "web"]

--- a/forgejo-1.19.3/build.sh
+++ b/forgejo-1.19.3/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-docker build -t forgejo .

--- a/forgejo-1.19.3/docker-compose.yaml
+++ b/forgejo-1.19.3/docker-compose.yaml
@@ -5,9 +5,11 @@ networks:
     external: false
 
 services:
-  server:
-    image: forgejo
-    container_name: forgejo
+  forgejo_server:
+    build: .
+    image: nico-labs/forgejo_server:1.0
+    container_name: forgejo_server
+    hostname: forgejo_server
     environment:
       - USER_UID=1000
       - USER_GID=1000
@@ -23,7 +25,7 @@ services:
     ports:
       - "3000:3000"
       - "2222:2222"
-  registry:
+  registry: 
     restart: always
     image: registry:2
     ports:

--- a/forgejo-1.19.3/docker-compose.yaml
+++ b/forgejo-1.19.3/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     ports:
       - "3000:3000"
       - "2222:2222"
-  registry: 
+  registry: #not tested
     restart: always
     image: registry:2
     ports:


### PR DESCRIPTION
Refactored to download forgejo binary from source during build.
Docker-compose to initiate build, build.sh no longer needed